### PR TITLE
Add Lightning version to bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "postinstall": "rollup -c"
   },
   "dependencies": {
-    "rollup": "^0.67.0"
+    "rollup": "^0.67.0",
+    "rollup-plugin-license": "^0.10.0"
   },
   "repository": {
     "type": "git",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,8 +1,17 @@
 const resolve = require('./rollup.plugin.resolver');
+import license from 'rollup-plugin-license';
+import pkg from './package.json';
 
 export default {
     input: './src/lightning.mjs',
-    plugins: [resolve("web")],
+    plugins: [
+        resolve("web"),
+
+        /* Add version number to bundle */
+        license({
+            banner: `Lightning v<%= pkg.version %>\n\n https://github.com/WebPlatformForEmbedded/Lightning`,
+          }),
+    ],
     output: {
         file: './dist/lightning-web.js',
         format: 'iife',


### PR DESCRIPTION
This change will add version information at the top of Lightning bundle created by rollup:

```javascript
/**
 * Lightning v1.0.6
 *
 * https://github.com/WebPlatformForEmbedded/Lightning
 */
```