### PR TITLE
Update rollup and es5 config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -903,15 +903,21 @@
       "dev": true
     },
     "@types/estree": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "version": "0.0.42",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.42.tgz",
+      "integrity": "sha512-K1DPVvnBCPxzD+G51/cxVIoc2X8uUVl1zpJeE6iKcgHMj4+tbat5Xu4TjV7v2QSDbIeAfLi2hIk+u2+s0MlpUQ==",
       "dev": true
     },
     "@types/node": {
-      "version": "13.1.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.7.tgz",
-      "integrity": "sha512-HU0q9GXazqiKwviVxg9SI/+t/nAsGkvLDkIdxz+ObejG2nX6Si00TeLqHMoS+a/1tjH7a8YpKVQwtgHuMQsldg==",
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.0.tgz",
+      "integrity": "sha512-Onhn+z72D2O2Pb2ql2xukJ55rglumsVo1H6Fmyi8mlU9SvKdBk/pUSUAiBY/d9bAOF7VVWajX3sths/+g6ZiAQ==",
+      "dev": true
+    },
+    "acorn": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
       "dev": true
     },
     "ansi-colors": {
@@ -1900,13 +1906,14 @@
       }
     },
     "rollup": {
-      "version": "0.67.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.67.4.tgz",
-      "integrity": "sha512-AVuP73mkb4BBMUmksQ3Jw0jTrBTU1i7rLiUYjFxLZGb3xiFmtVEg40oByphkZAsiL0bJC3hRAJUQos/e5EBd+w==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.30.1.tgz",
+      "integrity": "sha512-Uus8mwQXwaO+ZVoNwBcXKhT0AvycFCBW/W8VZtkpVGsotRllWk9oldfCjqWmTnFRI0y7x6BnEqSqc65N+/YdBw==",
       "dev": true,
       "requires": {
-        "@types/estree": "0.0.39",
-        "@types/node": "*"
+        "@types/estree": "*",
+        "@types/node": "*",
+        "acorn": "^7.1.0"
       }
     },
     "rollup-plugin-babel": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@babel/preset-env": "^7.8.3",
     "chai": "^4.2.0",
     "mocha": "^6.2.1",
-    "rollup": "^0.67.0",
+    "rollup": "^1.30.1",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-license": "^0.10.0",
     "rollup-plugin-terser": "^5.1.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -58,7 +58,7 @@ export default [{
                 '@babel/env',
                 {
                     targets: {
-                        chrome: '44',
+                        ie: '11',
                     },
                     spec: true,
                     debug: false
@@ -90,7 +90,7 @@ export default [{
                 '@babel/env',
                 {
                     targets: {
-                        chrome: '44',
+                        ie: '11',
                     },
                     spec: true,
                     debug: false
@@ -118,7 +118,7 @@ export default [{
                 '@babel/env',
                 {
                     targets: {
-                        chrome: '44',
+                        ie: '11',
                     },
                     spec: true,
                     debug: false


### PR DESCRIPTION
* Update rollup to latest version
* Update es5 transpilation target to exclude more of modern features (object property shorthand, typeof operator, template literals)