### PR TITLE
Added _bootstrap hook, updated example.

### DIFF
--- a/examples/basic-usage/web-bundle/basic-usage.html
+++ b/examples/basic-usage/web-bundle/basic-usage.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
 
-    <script src="../../../dist/lightning-web.js"></script>
+    <script type='module' src="../../../index.js"></script>
     <script src="../../../devtools/lightning-inspect.js"></script>
 </head>
 <body>
@@ -12,6 +12,12 @@
 
         window.onload = function() {
             class BasicUsageExample extends lng.Application {
+
+                static _bootstrap() {
+                    // Start app after 3 seconds
+                    return new Promise((resolve) => setTimeout(resolve, 3000))
+                }
+
                 static _template() {
                     return {
                         Bg: {
@@ -46,9 +52,13 @@
 
             const options = {stage: {w: 900, h: 900, clearColor: 0xFF000000, canvas2d: false, useImageWorker: false}, debug: true}
 
-            const app = new BasicUsageExample(options);
+            BasicUsageExample._bootstrap()
+            .then(() => {
+                const app = new BasicUsageExample(options);
+                document.body.appendChild(app.stage.getCanvas());
+            });
 
-            document.body.appendChild(app.stage.getCanvas());
+
         }
     </script>
 </body>

--- a/src/application/Application.mjs
+++ b/src/application/Application.mjs
@@ -3,6 +3,9 @@ import Utils from "../tree/Utils.mjs";
 
 export default class Application extends Component {
 
+    static async _bootstrap() {
+    }
+
     constructor(options = {}, properties) {
         // Save options temporarily to avoid having to pass it through the constructor.
         Application._temp_options = options;


### PR DESCRIPTION
`_bootstrap` hook allows certain asynchronous operations (like https requests) to finish before before app starts. This allows e.g. asset preloading.